### PR TITLE
added to filter func for links with spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,6 @@ const async = require('async');
 const url = require('url');
 const ProgressBar = require('progress');
 
-
-
 class SiteMapCrawler {
   static start(links, isProgress, isLog, isCounting, callback) {
     const siteMap = {};

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ const async = require('async');
 const url = require('url');
 const ProgressBar = require('progress');
 
+
+
 class SiteMapCrawler {
   static start(links, isProgress, isLog, isCounting, callback) {
     const siteMap = {};
@@ -80,21 +82,24 @@ class SiteMapCrawler {
       '^mailto',
       'admin',
       'login',
-      'register'
+      'register',
+      ' '
     ];
     const rIgnores = new RegExp(ignores.join('|'), 'i');
 
-    if (href.startsWith('http')) {
-      const parentHostName = new URL(parent).hostname;
-      const hrefHostName = new URL(href).hostname;
+    if (href.indexOf(' ') < 0)) {
+      if (href.startsWith('http')) {
+        const parentHostName = new URL(parent).hostname;
+        const hrefHostName = new URL(href).hostname;
 
-      if (parentHostName === hrefHostName && !(href.match(rIgnores))) {
-        return href;
+        if (parentHostName === hrefHostName && !(href.match(rIgnores))) {
+          return href;
+        }
       }
-    }
 
-    if (!(href.match(rIgnores)) && !(href.includes('//'))) {
-      return url.resolve(parent, href);
+      if (!(href.match(rIgnores)) && !(href.includes('//'))) {
+        return url.resolve(parent, href);
+      }
     }
 
     return null;

--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ class SiteMapCrawler {
     ];
     const rIgnores = new RegExp(ignores.join('|'), 'i');
 
-    if (href.indexOf(' ') < 0)) {
+    if (href.indexOf(' ') < 0) {
       if (href.startsWith('http')) {
         const parentHostName = new URL(parent).hostname;
         const hrefHostName = new URL(href).hostname;

--- a/index.js
+++ b/index.js
@@ -82,8 +82,7 @@ class SiteMapCrawler {
       '^mailto',
       'admin',
       'login',
-      'register',
-      ' '
+      'register'
     ];
     const rIgnores = new RegExp(ignores.join('|'), 'i');
 


### PR DESCRIPTION
Heyo, ran into a crash when the tool finds a link like this:

`https://dumbguy.com/i suck at making links.html`

For whatever reason adding ' ' and \s to the ignore list didn't work for me, which is what I tried first.